### PR TITLE
Add support for double-sided shapes

### DIFF
--- a/luaglue.c
+++ b/luaglue.c
@@ -637,6 +637,12 @@ static int shape_setClosed(lua_State* L)
 	return 0;
 }
 
+static int shape_setFaceDoubleSided(lua_State* L)
+{
+	Shape3D_setFaceDoubleSided(getShape(1), pd->lua->getArgInt(2), pd->lua->getArgBool(3));
+	return 0;
+}
+
 static int shape_collideSphere(lua_State* L)
 {
 	Shape3D* shape = getShape(1);
@@ -741,6 +747,7 @@ static const lua_reg lib3DShape[] =
 	{ "addFace",		shape_addFace },
 	{ "setClosed", 		shape_setClosed },
 	{ "collidesSphere", shape_collideSphere },
+	{ "setFaceDoubleSided", shape_setFaceDoubleSided },
 #if ENABLE_TEXTURES
 		{ "setTexture",		shape_setTexture },
 		{ "setFaceTextureMap", shape_setFaceTextureMap},

--- a/mini3d-plus/scene.c
+++ b/mini3d-plus/scene.c
@@ -188,6 +188,7 @@ Scene3DNode_addShapeWithTransform(Scene3DNode* node, Shape3D* shape, Matrix3D tr
 
 		// also not necessary
 		face->normal = normal(face->p1, face->p2, face->p3);
+		face->isDoubleSided = shape->faces[i].isDoubleSided;
 	}
 	
 	nodeshape->header.transform = transform;
@@ -741,6 +742,7 @@ Scene3D_updateShapeInstance(Scene3D* scene, ShapeInstance* shape, Matrix3D xform
 	{
 		FaceInstance* face = &shape->faces[i];
 		face->normal = normal(face->p1, face->p2, face->p3);
+		face->isDoubleSided = shape->faces[i].isDoubleSided;
 		
 #if ENABLE_ORDERING_TABLE
 		if ( ordersize > 0 )
@@ -1049,7 +1051,7 @@ drawShapeFace(Scene3D* scene, ShapeInstance* shape, uint8_t* bitmap, int rowstri
 		 (y1 >= VIEWPORT_BOTTOM && y2 >= VIEWPORT_BOTTOM && y3 >= VIEWPORT_BOTTOM && (face->p4 == NULL || face->p4->y >= VIEWPORT_BOTTOM)) )
 		return;
 
-	if ( shape->prototype->isClosed )
+	if ( shape->prototype->isClosed && !face->isDoubleSided )
 	{
 		// only render front side of faces
 

--- a/mini3d-plus/scene.h
+++ b/mini3d-plus/scene.h
@@ -30,6 +30,7 @@ struct FaceInstance
 #if ENABLE_ORDERING_TABLE
 	struct FaceInstance* next;
 #endif
+	int isDoubleSided : 1;
 };
 typedef struct FaceInstance FaceInstance;
 

--- a/mini3d-plus/shape.c
+++ b/mini3d-plus/shape.c
@@ -146,6 +146,12 @@ void Shape3D_setClosed(Shape3D* shape, int flag)
 	shape->isClosed = flag;
 }
 
+void Shape3D_setFaceDoubleSided(Shape3D* shape, size_t face_idx, int flag)
+{
+	if (face_idx < shape->nFaces)
+		shape->faces[face_idx].isDoubleSided = flag;
+}
+
 #if ENABLE_TEXTURES
 void Shape3D_setFaceTextureMap(
 	Shape3D* shape, size_t face_idx,

--- a/mini3d-plus/shape.c
+++ b/mini3d-plus/shape.c
@@ -117,6 +117,7 @@ size_t Shape3D_addFace(Shape3D* shape, Point3D* a, Point3D* b, Point3D* c, Point
 	face->p3 = Shape3D_addPoint(shape, c);
 	face->p4 = (d != NULL) ? Shape3D_addPoint(shape, d) : 0xffff;
 	face->colorBias = colorBias;
+	face->isDoubleSided = 0;
 	
 	++shape->nFaces;
 	

--- a/mini3d-plus/shape.h
+++ b/mini3d-plus/shape.h
@@ -21,6 +21,7 @@ typedef struct
 	uint16_t p3;
 	uint16_t p4; // 0xffff if it's a tri
 	float colorBias;
+	int isDoubleSided : 1;
 } Face3D;
 
 #if ENABLE_TEXTURES
@@ -80,6 +81,8 @@ void Shape3D_release(Shape3D* shape);
 size_t Shape3D_addFace(Shape3D* shape, Point3D* a, Point3D* b, Point3D* c, Point3D* d, float colorBias);
 
 void Shape3D_setClosed(Shape3D* shape, int flag);
+
+void Shape3D_setFaceDoubleSided(Shape3D* shape, size_t face_idx, int flag);
 
 #if ENABLE_TEXTURES
 // t4 can be set to anything if not used


### PR DESCRIPTION
This allows a shape to render one of its faces on the front and the back. It uses the same logic as the shape's "closed" property so it shouldn't introduce any rendering lag.

Front side:
![front](https://user-images.githubusercontent.com/241156/166691604-db586c96-a3fe-469e-bcd7-81e391576304.png)

Back side:
![back](https://user-images.githubusercontent.com/241156/166691603-566e245f-c061-405c-8914-c2da2753b519.png)
 