### PR TITLE
Fix crash in overrelease of `node->instances`

### DIFF
--- a/mini3d-plus/scene.c
+++ b/mini3d-plus/scene.c
@@ -61,9 +61,6 @@ Scene3DNode_deinit(Scene3DNode* node)
 		instance = next;
 	}
 	
-	if ( node->instances != NULL )
-		m3d_free(node->instances);
-		
 	int i;
 	
 	for ( i = 0; i < node->nChildren; ++i )


### PR DESCRIPTION
In the code that runs before the deleted lines, the `node->instances` linked list is iterated and each item in the list is freed using `m3d_free`. That means the linked list's head has already been freed by the time the `m3d_free(node->instances)` call happens.

I didn't notice this crash earlier because my `lib3d.scene` object was a global but now I have multiple scenes that I switch between over the course of my game.